### PR TITLE
Fix username validation regex to correctly recognize hyphen (-)

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	usernameRegexp       = `^([a-zA-Z0-9_.-@])+$`
+	usernameRegexp       = `^([a-zA-Z0-9_.\-@])+$`
 	passwordMinLength    = 6
 	certsArchiveFileName = "certs.tar.gz"
 	ccdArchiveFileName   = "ccd.tar.gz"


### PR DESCRIPTION
This pull request corrects the regular expression used for username validation to correctly recognize hyphens (-).

**Changes Made:**
Changed the regex pattern from ^([a-zA-Z0-9_.-@])+$ to ^([a-zA-Z0-9_.\-@])+$.

**Reason for Change:**
In the previous regex, the hyphen (-) within the character class was interpreted as a range operator, not as a literal character. This caused usernames with hyphens to be incorrectly marked as invalid. By escaping the hyphen (\-), the regex now correctly recognizes it as a literal character. This ensures that usernames containing hyphens are validated properly.

**Points of Verification:**
Confirmed that usernames containing hyphens are now correctly recognized and pass the validation. Verified that other characters (letters, numbers, underscores, dots, and at signs) are still being properly validated.
[regextest.go.txt](https://github.com/user-attachments/files/17173832/regextest.go.txt)
