### PR TITLE
fixing docker-compose.yaml to point to right dockerfile

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
   ovpn-admin:
     build:
       context: .
+      dockerfile: Dockerfile.ovpn-admin
     image: ovpn-admin:local
     command: /app/ovpn-admin
     environment:


### PR DESCRIPTION
Otherwise the `./start.sh` script fails. 