### PR TITLE
Fix easyrsa init-pki prompt confirmation

### DIFF
--- a/setup/configure.sh
+++ b/setup/configure.sh
@@ -21,7 +21,7 @@ else
     done
   else
     echo "Generating new certs"
-    easyrsa init-pki
+    easyrsa --batch init-pki
     cp -R /usr/share/easy-rsa/* $EASY_RSA_LOC/pki
     echo "ca" | easyrsa build-ca nopass
     easyrsa build-server-full server nopass


### PR DESCRIPTION
Invoking `easyrsa init-pki` in `setup/configure.sh` waits for confirmation if the `pki` directory already exists. Fixing it by adding the `--batch` option flag.

Fixes #245