### PR TITLE
Fix easyrsa build-server-full prompt

### DIFF
--- a/setup/configure.sh
+++ b/setup/configure.sh
@@ -24,7 +24,7 @@ else
     easyrsa --batch init-pki
     cp -R /usr/share/easy-rsa/* $EASY_RSA_LOC/pki
     echo "ca" | easyrsa build-ca nopass
-    easyrsa build-server-full server nopass
+    easyrsa --batch build-server-full server nopass
     easyrsa gen-dh
     openvpn --genkey --secret ./pki/ta.key
   fi


### PR DESCRIPTION
A follow-up fix for #355 as a similar issue affected the `easyrsa build-server-full` command resulting in the following `docker logs` for the `openvpn` (not `ovpn-admin`) container:

```
...
Private-Key and Public-Certificate-Request files created.
Your files are:
* req: /etc/openvpn/easyrsa/pki/reqs/server.req
* key: /etc/openvpn/easyrsa/pki/private/server.key

You are about to sign the following certificate:

  Requested CN:     'server'
  Requested type:   'server'
  Valid for:        '825' days


subject=
    commonName                = server

Type the word 'yes' to continue, or any other input to abort.
  Confirm requested details: 

Notice
------
Aborting without confirmation.
```