### PR TITLE
Fix easyrsa build-client-full command

### DIFF
--- a/main.go
+++ b/main.go
@@ -992,7 +992,7 @@ func (oAdmin *OvpnAdmin) userCreate(username, password string) (bool, string) {
 			log.Error(err)
 		}
 	} else {
-		o := runBash(fmt.Sprintf("cd %s && %s build-client-full %s nopass 1>/dev/null", *easyrsaDirPath, *easyrsaBinPath, username))
+		o := runBash(fmt.Sprintf("cd %s && %s --batch build-client-full %s nopass 1>/dev/null", *easyrsaDirPath, *easyrsaBinPath, username))
 		log.Debug(o)
 	}
 


### PR DESCRIPTION
The actual `easyrsa` version now requires the `--batch` flag to proceed with the `build-client-full` command silently (with no user prompt). This command was used in our `userCreate`, leading to have users created in the `users.db` database, but not `index.txt`.

Fixes #358
